### PR TITLE
PromotionBot: Promote dev2 to prod2

### DIFF
--- a/prod2/fake-deployment.yaml
+++ b/prod2/fake-deployment.yaml
@@ -4,5 +4,5 @@ version: |
   image:
     repository: "ghcr.io/mastercontrolinc/audit-trail"
     pullPolicy: IfNotPresent
-    tag: "0.1.618"
+    tag: "0.1.622"
 


### PR DESCRIPTION
# Promote dev2 to prod2

## Change Summary

 - - updating sonarcloud token (version: v0.1.622) ([checks](https://github.com/MasterControlInc/audit-trail/pull/423/checks))
- Bump io.netty:netty-codec from 4.1.87.Final to 4.1.89.Final (version: v0.1.621) ([checks](https://github.com/MasterControlInc/audit-trail/pull/416/checks))
- Bump micrometer-registry-jmx from 1.10.2 to 1.10.3 (version: v0.1.620) ([checks](https://github.com/MasterControlInc/audit-trail/pull/333/checks))
- Bump com.mastercontrol.build-conventions from 1.0.7 to 1.0.11 (version: v0.1.619) ([checks](https://github.com/MasterControlInc/audit-trail/pull/386/checks))

