### PR TITLE
PromotionBot: Promote dev2 to prod2

### DIFF
--- a/prod2/fake-deployment.yaml
+++ b/prod2/fake-deployment.yaml
@@ -4,5 +4,5 @@ version: |
   image:
     repository: "ghcr.io/mastercontrolinc/audit-trail"
     pullPolicy: IfNotPresent
-    tag: "0.1.622"
+    tag: "0.1.624"
 


### PR DESCRIPTION
# Promote dev2 to prod2

<!-- BEGIN E2E TEST DATA 4515290099 -->
## End to End API/UI Test Results

✅ [Passing](https://github.com/MasterControlInc/Test-Automation-Framework/actions/runs/4515290099) as of `2023-03-24 20:58:19 UTC`.
<!-- END E2E TEST DATA -->


## Change Summary

<details><summary>Column Descriptions</summary>

* **Commit Status** reports the summary result of workflows run against the commit on the main branch tagged with the version for release, click to navigate to this commit
* **PR Status**  reports the summary result of workflows run against the latest commit on the PR source branch, click to navigate to this commit
* **Pull Request Title** should be self explanatory
* **Version** is the version tag associated with each release; every release made after the version previously configured for deployment in the target environment up to and including the proposed new version to promote is represented if a commit can be found for it
* **Checks** provides a hyperlink to the "Checks" tab on the PR in the application's repository

</details>

### Audit Trail
###### _v0.1.622 → v0.1.624_
| Commit Status | PR Status |Pull Request Title<br><img width="10000" height="1"> | Version<br><img height="1" width="1"> | Checks<br><img height="1" width="1"> |
| :---: | :---: | :--- | :---: | :---: |
|[✅](https://github.com/MasterControlInc/audit-trail/commit/de01714172c43d25bbec8985990d0e040105504b)|[⛔️](https://github.com/MasterControlInc/audit-trail/commit/a3c2f55a89c61359ba7b52a061868bfed6860a91)| changing badge link to service overview |v0.1.624 |[#427](https://github.com/MasterControlInc/audit-trail/pull/427/checks)|
|[✅](https://github.com/MasterControlInc/audit-trail/commit/382161c0dde3d25ed9eb2ebf74ccf4d8858e53fb)|[⛔️](https://github.com/MasterControlInc/audit-trail/commit/df98e976a04ce1eb7c2ddc438e0a4fb680246812)| Update README.md to remove badges |v0.1.623 |[#426](https://github.com/MasterControlInc/audit-trail/pull/426/checks)|


